### PR TITLE
Snapshot Import/Export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,5 @@ dist
 .DS_Store
 
 # ignore snapshots folder for now
-tools/snapshot-eq/snapshots/
+snapshots/
+snapshot-archives/*.zip

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This project provides a suite of tools for verifying that [ENSNode](https://gith
 
 ### todo
 
-- [ ] include snapshots, as git LFS or zip somewhere
 - [ ] add events top-level queries
+- [ ] include snapshots, as git LFS or zip somewhere
 - [ ] configure tools index's as bin for simpler calling
 
 ## snapshot equivalency tool (`snapshot-eq`)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This project provides a suite of tools for verifying that [ENSNode](https://gith
 
 ### todo
 
-- [ ] resolver.addr (and therefore Domain.resolvedAddress) is null in many (but not all) cases
-  - seems that resolver factory events aren't being indexed, inc. the former public resolver `0x1da022710df5002339274aadee8d58218e9d6ab5`
-- [ ] enforce static order with `orderBy: id`, dependent on orderBy enum support in ENSNode
 - [ ] include snapshots, as git LFS or zip somewhere
 - [ ] add events top-level queries
 - [ ] configure tools index's as bin for simpler calling
@@ -19,14 +16,14 @@ configure via env variables or `.env.local` at root of project or inline
 - `PONDER_API_URL`
 - `SUBGRAPH_API_KEY`
 
-commands:
-- `bun run start -- --help`
-- `bun run start -- snapshot <blockheight> <ponder|subgraph>`
+commands, (run from the root of the project):
+- `bun snapshot-eq --help`
+- `bun snapshot-eq snapshot <blockheight> <ponder|subgraph>`
   - takes a 'snapshot' of the indexer at the provided blockheight by iterating over `n` collection queries
     - persists responses to `snapshots/[:blockheight]/[:indexer]/[:operationKey].json`
   - if ponder, code enforces that the indexer is ready at that blockheight
   - if subgraph, timetravel queries are used
-- `bun run start -- clean <blockheight> <ponder|subgraph>`
+- `bun snapshot-eq clean <blockheight> <ponder|subgraph>`
   - deletes the `snapshots/[:blockheight]/[:indexer]/` directory to bust the snapshot cache
 - `diff <blockheight>`
   - using subgraph responses as the source of truth, compares the snapshots at `snapshots/[:blockheight]/subgraph/*.json` wtih those at `snapshots/[:blockheight]/ponder/*.json` and prints the differences between them to assist with debugging

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ This project provides a suite of tools for verifying that [ENSNode](https://gith
 
 ### todo
 
-- [ ] add events top-level queries
-- [ ] include snapshots, as git LFS or zip somewhere
-- [ ] configure tools index's as bin for simpler calling
+- [ ] after integrating label healing, submit new snapshots
+- [ ] add exhaustive events export to relevant entities
 
 ## snapshot equivalency tool (`snapshot-eq`)
 
@@ -37,6 +36,28 @@ an `operationKey` is a [deterministic hash of a graphql document + variables](ht
 for the subgraph, [timetravel queries](https://thegraph.com/docs/en/subgraphs/querying/graphql-api/#time-travel-queries) are used to retrieve data at a specific blockheight.
 
 for ENSNode, timetravel is not supported, so the Ponder indexer inside ENSNode should be run until the specified `endBlock` and then snapshotted with this tool. in the future this may be automated, but currently the tool just enforces this context and relies on the user to run the `ensnode` project in parallel.
+
+### Snapshot Archives
+
+Snapshots are available in our [releases](https://github.com/namehash/ens-subgraph-transition-tools/releases) if you'd like to download and diff them yourself.
+
+To do so, follow the following
+
+```bash
+# download ponder snapshot to snapshot-exports
+wget -P snapshot-exports <url/for/blockheight-ponder.zip>
+# download subgraph snapshot to snapshot-exports
+wget -P snapshot-exports <url/for/blockheight-subgraph.zip>
+
+# unzips to snapshots/[:blockheight]/ponder/
+bun snapshot-eq import 21000000 ponder
+
+# unzips to snapshots/[:blockheight]/subgraph/
+bun snapshot-eq import 21000000 subgraph
+
+# diff the two snapshots
+bun snapshot-eq diff 21000000
+```
 
 ## api equivalency tool (`api-eq`)
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "packages/*"
   ],
   "scripts": {
-    "proxy:dev": "bun --filter=\"proxy-eq\" dev",
-    "snapshot:dev": "bun --filter=\"snapshot-eq\" dev"
+    "proxy:dev": "bun --filter proxy-eq dev",
+    "snapshot:dev": "bun --filter snapshot-eq dev",
+    "snapshot-eq": "bun --filter snapshot-eq --elide-lines 0 start"
   }
 }

--- a/tools/snapshot-eq/commands/export-command.ts
+++ b/tools/snapshot-eq/commands/export-command.ts
@@ -1,0 +1,12 @@
+import { makeSnapshotArchivePath, makeSnapshotDirectoryPath } from "@/lib/snapshots";
+import type { Indexer } from "@/lib/types";
+
+export async function exportCommand(blockheight: number, indexer: Indexer) {
+	const inputDirectory = makeSnapshotDirectoryPath({ blockheight, indexer });
+	const outputFilepath = makeSnapshotArchivePath({ blockheight, indexer });
+	const proc = Bun.spawnSync(["zip", "-j", "-r", outputFilepath, inputDirectory]);
+	if (!proc.success) {
+		console.error(proc.stderr);
+		throw new Error(`Could not zip ${inputDirectory}`);
+	}
+}

--- a/tools/snapshot-eq/commands/import-command.ts
+++ b/tools/snapshot-eq/commands/import-command.ts
@@ -1,0 +1,12 @@
+import { makeSnapshotArchivePath, makeSnapshotDirectoryPath } from "@/lib/snapshots";
+import type { Indexer } from "@/lib/types";
+
+export async function importCommand(blockheight: number, indexer: Indexer) {
+	const inputFilePath = makeSnapshotArchivePath({ blockheight, indexer });
+	const outputDirectory = makeSnapshotDirectoryPath({ blockheight, indexer });
+	const proc = Bun.spawnSync(["unzip", inputFilePath, "-d", outputDirectory]);
+	if (!proc.success) {
+		console.error(proc.stderr);
+		throw new Error(`Could not unzip ${inputFilePath}`);
+	}
+}

--- a/tools/snapshot-eq/index.ts
+++ b/tools/snapshot-eq/index.ts
@@ -4,6 +4,8 @@ import yargs from "yargs/yargs";
 import { cleanCommand } from "@/commands/clean-command";
 import { diffCommand } from "@/commands/diff-command";
 import { snapshotCommand } from "@/commands/snapshot-command";
+import { exportCommand } from "./commands/export-command";
+import { importCommand } from "./commands/import-command";
 
 yargs(process.argv.slice(2))
 	.scriptName("snapshot-eq")
@@ -59,6 +61,46 @@ yargs(process.argv.slice(2))
 		},
 		async (argv) => {
 			await diffCommand(argv.blockheight);
+		},
+	)
+	.command(
+		"export <blockheight> <indexer>",
+		"Export snapshot archive",
+		(yargs) => {
+			return yargs
+				.positional("blockheight", {
+					type: "number",
+					description: "Block height to export",
+					demandOption: true,
+				})
+				.positional("indexer", {
+					choices: Object.values(Indexer),
+					description: "Indexer to export",
+					demandOption: true,
+				});
+		},
+		async (argv) => {
+			await exportCommand(argv.blockheight, argv.indexer as Indexer);
+		},
+	)
+	.command(
+		"import <blockheight> <indexer>",
+		"Import snapshot archive",
+		(yargs) => {
+			return yargs
+				.positional("blockheight", {
+					type: "number",
+					description: "Block height to import",
+					demandOption: true,
+				})
+				.positional("indexer", {
+					choices: Object.values(Indexer),
+					description: "Indexer to import",
+					demandOption: true,
+				});
+		},
+		async (argv) => {
+			await importCommand(argv.blockheight, argv.indexer as Indexer);
 		},
 	)
 	.strict()

--- a/tools/snapshot-eq/lib/snapshots.ts
+++ b/tools/snapshot-eq/lib/snapshots.ts
@@ -1,4 +1,9 @@
+import { resolve } from 'node:path'
+
 import type { Indexer } from "./types";
+
+// NOTE: don't love this, is there a better way to get to the root of the monorepo?
+const projectRootDir = resolve(__dirname, '../../..')
 
 export function makeSnapshotDirectoryPath({
 	blockheight,
@@ -7,7 +12,7 @@ export function makeSnapshotDirectoryPath({
 	blockheight: number;
 	indexer: Indexer;
 }) {
-	return ["snapshots", blockheight, indexer].join("/");
+	return resolve(projectRootDir, "snapshots", blockheight.toString(), indexer);
 }
 
 export function makeSnapshotPath({
@@ -19,7 +24,7 @@ export function makeSnapshotPath({
 	indexer: Indexer;
 	operationKey: string;
 }) {
-	return [makeSnapshotDirectoryPath({ blockheight, indexer }), `${operationKey}.json`].join("/");
+	return resolve(makeSnapshotDirectoryPath({ blockheight, indexer }), `${operationKey}.json`);
 }
 
 export async function hasSnapshot(path: string) {
@@ -27,5 +32,5 @@ export async function hasSnapshot(path: string) {
 }
 
 export async function persistSnapshot(path: string, response: string) {
-	await Bun.write(path, response);
+	return await Bun.write(path, response);
 }

--- a/tools/snapshot-eq/lib/snapshots.ts
+++ b/tools/snapshot-eq/lib/snapshots.ts
@@ -1,9 +1,9 @@
-import { resolve } from 'node:path'
+import { resolve } from "node:path";
 
 import type { Indexer } from "./types";
 
 // NOTE: don't love this, is there a better way to get to the root of the monorepo?
-const projectRootDir = resolve(__dirname, '../../..')
+const projectRootDir = resolve(__dirname, "../../..");
 
 export function makeSnapshotDirectoryPath({
 	blockheight,
@@ -13,6 +13,16 @@ export function makeSnapshotDirectoryPath({
 	indexer: Indexer;
 }) {
 	return resolve(projectRootDir, "snapshots", blockheight.toString(), indexer);
+}
+
+export function makeSnapshotArchivePath({
+	blockheight,
+	indexer,
+}: {
+	blockheight: number;
+	indexer: Indexer;
+}) {
+	return resolve(projectRootDir, "snapshot-archives", `${blockheight}-${indexer}.zip`);
 }
 
 export function makeSnapshotPath({


### PR DESCRIPTION
- `bun snapshot-eq export 21000000 subgraph` zips to archive
- `bun snapshot-eq import 21000000 subgraph` unpacks to snapshot folder
- manually store archive zips in github releases

https://github.com/namehash/ens-subgraph-transition-tools/releases/tag/v0.0.1